### PR TITLE
refs #53 - reuse policies of http.request instances

### DIFF
--- a/src/client/api_rest.go
+++ b/src/client/api_rest.go
@@ -12,6 +12,7 @@ import (
 	"github.com/simelo/rextporter/src/util"
 )
 
+// APIRestCreator have info to create api rest an client
 type APIRestCreator struct {
 	httpMethod           string
 	dataPath             string
@@ -20,7 +21,8 @@ type APIRestCreator struct {
 	tokenKeyFromEndpoint string
 }
 
-func CreateAPIRestCreator(metric config.Metric, service config.Service) (cf CacheableClientFactory, err error) {
+// CreateAPIRestCreator create an APIRestCreator
+func CreateAPIRestCreator(metric config.Metric, service config.Service) (cf CacheableFactory, err error) {
 	cf = APIRestCreator{
 		httpMethod:           metric.HTTPMethod,
 		dataPath:             service.URIToGetMetric(metric),
@@ -31,6 +33,7 @@ func CreateAPIRestCreator(metric config.Metric, service config.Service) (cf Cach
 	return cf, err
 }
 
+// CreateClient create an api rest client
 func (ac APIRestCreator) CreateClient() (cl CacheableClient, err error) {
 	const generalScopeErr = "error creating api rest client"
 	var req *http.Request
@@ -39,7 +42,7 @@ func (ac APIRestCreator) CreateClient() (cl CacheableClient, err error) {
 		return APIRest{}, util.ErrorFromThisScope(errCause, generalScopeErr)
 	}
 	var tokenClient Client
-	tc := TokenCreator{UriToGenToken: ac.tokenPath}
+	tc := TokenCreator{URIToGenToken: ac.tokenPath}
 	if tokenClient, err = tc.CreateClient(); err != nil {
 		errCause := fmt.Sprintln("create token client: ", err.Error())
 		return APIRest{}, util.ErrorFromThisScope(errCause, generalScopeErr)

--- a/src/client/api_rest.go
+++ b/src/client/api_rest.go
@@ -44,13 +44,14 @@ func (ac APIRestCreator) CreateClient() (cl CacheableClient, err error) {
 		errCause := fmt.Sprintln("create token client: ", err.Error())
 		return APIRest{}, util.ErrorFromThisScope(errCause, generalScopeErr)
 	}
-	return APIRest{
+	cl = APIRest{
 		baseCacheableClient:  baseCacheableClient(ac.dataPath),
 		req:                  req,
 		tokenClient:          tokenClient,
 		tokenHeaderKey:       ac.tokenHeaderKey,
 		tokenKeyFromEndpoint: ac.tokenKeyFromEndpoint,
-	}, nil
+	}
+	return cl, nil
 }
 
 // APIRest have common data to be shared through embedded struct in those type who implement the client.Client interface

--- a/src/client/api_rest.go
+++ b/src/client/api_rest.go
@@ -38,8 +38,9 @@ func (ac APIRestCreator) CreateClient() (cl CacheableClient, err error) {
 		errCause := fmt.Sprintln("can not create the request client: ", err.Error())
 		return APIRest{}, util.ErrorFromThisScope(errCause, generalScopeErr)
 	}
-	var tokenClient TokenClient
-	if tokenClient, err = newTokenClient(ac.tokenPath); err != nil {
+	var tokenClient Client
+	tc := TokenCreator{UriToGenToken: ac.tokenPath}
+	if tokenClient, err = tc.CreateClient(); err != nil {
 		errCause := fmt.Sprintln("create token client: ", err.Error())
 		return APIRest{}, util.ErrorFromThisScope(errCause, generalScopeErr)
 	}
@@ -56,7 +57,7 @@ func (ac APIRestCreator) CreateClient() (cl CacheableClient, err error) {
 type APIRest struct {
 	baseCacheableClient
 	req                  *http.Request
-	tokenClient          TokenClient
+	tokenClient          Client
 	tokenHeaderKey       string
 	tokenKeyFromEndpoint string
 	token                string

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -12,13 +12,13 @@ type CacheableClient interface {
 	DataPath() string
 }
 
-// ClientFactory can create diffrent kind of clients
-type ClientFactory interface {
+// Factory can create different kind of clients
+type Factory interface {
 	CreateClient() (cl Client, err error)
 }
 
-// CacheableClientFactory can create diffrent kind of cacheable clients
-type CacheableClientFactory interface {
+// CacheableFactory can create different kind of cacheable clients
+type CacheableFactory interface {
 	CreateClient() (cl CacheableClient, err error)
 }
 

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -12,6 +12,11 @@ type CacheableClient interface {
 	DataPath() string
 }
 
+// CacheableClientFactory can create diffrent kind of cacheable clients
+type CacheableClientFactory interface {
+	CreateClient() (cl CacheableClient, err error)
+}
+
 type baseCacheableClient string
 
 // DataPath is the endpoint in the case of http clients

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -12,6 +12,11 @@ type CacheableClient interface {
 	DataPath() string
 }
 
+// ClientFactory can create diffrent kind of clients
+type ClientFactory interface {
+	CreateClient() (cl Client, err error)
+}
+
 // CacheableClientFactory can create diffrent kind of cacheable clients
 type CacheableClientFactory interface {
 	CreateClient() (cl CacheableClient, err error)

--- a/src/client/client_catcher.go
+++ b/src/client/client_catcher.go
@@ -10,13 +10,11 @@ type CatcherCreator struct {
 }
 
 func (cc CatcherCreator) CreateClient() (cl Client, err error) {
-	var dataKey string
-	if ccl, err := cc.ClientFactory.CreateClient(); err == nil {
-		return cl, err
-	} else {
-		dataKey = ccl.DataPath()
+	var ccl CacheableClient
+	if ccl, err = cc.ClientFactory.CreateClient(); err != nil {
+		return ccl, err
 	}
-	return Catcher{cache: cc.Cache, dataKey: dataKey, clientFactory: cc.ClientFactory}, nil
+	return Catcher{cache: cc.Cache, dataKey: ccl.DataPath(), clientFactory: cc.ClientFactory}, nil
 }
 
 // Catcher have a client and a cache to save time loading data

--- a/src/client/client_catcher.go
+++ b/src/client/client_catcher.go
@@ -4,11 +4,13 @@ import (
 	"github.com/simelo/rextporter/src/cache"
 )
 
+// CatcherCreator have info to create catcher client
 type CatcherCreator struct {
 	Cache         cache.Cache
-	ClientFactory CacheableClientFactory
+	ClientFactory CacheableFactory
 }
 
+// CreateClient create a catcher client
 func (cc CatcherCreator) CreateClient() (cl Client, err error) {
 	var ccl CacheableClient
 	if ccl, err = cc.ClientFactory.CreateClient(); err != nil {
@@ -21,7 +23,7 @@ func (cc CatcherCreator) CreateClient() (cl Client, err error) {
 type Catcher struct {
 	cache         cache.Cache
 	dataKey       string
-	clientFactory CacheableClientFactory
+	clientFactory CacheableFactory
 }
 
 // GetData return the data, can be from local cache or making the original request

--- a/src/client/client_catcher.go
+++ b/src/client/client_catcher.go
@@ -4,26 +4,39 @@ import (
 	"github.com/simelo/rextporter/src/cache"
 )
 
-// Catcher have a client and a cache to save time loading data
-type Catcher struct {
-	cache cache.Cache
-	cl    CacheableClient
+type CatcherCreator struct {
+	Cache         cache.Cache
+	ClientFactory CacheableClientFactory
 }
 
-// NewCatcher create a Client compatible  catcher
-func NewCatcher(cl CacheableClient, cache cache.Cache) Client {
-	return Catcher{cache: cache, cl: cl}
+func (cc CatcherCreator) CreateClient() (cl Client, err error) {
+	var dataKey string
+	if ccl, err := cc.ClientFactory.CreateClient(); err == nil {
+		return cl, err
+	} else {
+		dataKey = ccl.DataPath()
+	}
+	return Catcher{cache: cc.Cache, dataKey: dataKey, clientFactory: cc.ClientFactory}, nil
+}
+
+// Catcher have a client and a cache to save time loading data
+type Catcher struct {
+	cache         cache.Cache
+	dataKey       string
+	clientFactory CacheableClientFactory
 }
 
 // GetData return the data, can be from local cache or making the original request
 func (cl Catcher) GetData() (body []byte, err error) {
-	dataKey := cl.cl.DataPath()
-	if body, err = cl.cache.Get(dataKey); err == nil {
+	if body, err = cl.cache.Get(cl.dataKey); err == nil {
 		return body, err
 	}
-	if body, err = cl.cl.GetData(); err == nil {
-		cl.cache.Set(dataKey, body)
+	var ccl CacheableClient
+	if ccl, err = cl.clientFactory.CreateClient(); err != nil {
+		return nil, err
+	}
+	if body, err = ccl.GetData(); err == nil {
+		cl.cache.Set(cl.dataKey, body)
 	}
 	return body, err
-	// return cl.cl.GetData()
 }

--- a/src/client/metrics_forwader.go
+++ b/src/client/metrics_forwader.go
@@ -12,11 +12,13 @@ import (
 	"github.com/simelo/rextporter/src/util"
 )
 
+// ProxyMetricClientCreator create a metrics fordwader client
 type ProxyMetricClientCreator struct {
 	dataPath    string
 	ServiceName string
 }
 
+// CreateProxyMetricClientCreator create a ProxyMetricClientCreator with required info to create a metrics fordwader client
 func CreateProxyMetricClientCreator(service config.Service) (cf ProxyMetricClientCreator, err error) {
 	if !util.StrSliceContains(service.Modes, config.ServiceTypeProxy) {
 		return ProxyMetricClientCreator{}, errors.New("can not create a forward_metrics metric client from a service whitout type " + config.ServiceTypeProxy)
@@ -28,6 +30,7 @@ func CreateProxyMetricClientCreator(service config.Service) (cf ProxyMetricClien
 	return cf, err
 }
 
+// CreateClient create a metrics forwader client
 func (pmc ProxyMetricClientCreator) CreateClient() (cl Client, err error) {
 	const generalScopeErr = "error creating a forward_metrics client to get the metrics from remote endpoint"
 	var req *http.Request

--- a/src/client/token.go
+++ b/src/client/token.go
@@ -8,12 +8,14 @@ import (
 	"github.com/simelo/rextporter/src/util"
 )
 
+// TokenCreator create token clients
 type TokenCreator struct {
-	UriToGenToken string
+	URIToGenToken string
 }
 
+// CreateClient create a token client
 func (tc TokenCreator) CreateClient() (cl Client, err error) {
-	return newTokenClient(tc.UriToGenToken)
+	return newTokenClient(tc.URIToGenToken)
 }
 
 // TokenClient implements the getRemoteInfo method from `client.Client` interface by using some .toml config parameters

--- a/src/client/token.go
+++ b/src/client/token.go
@@ -8,6 +8,14 @@ import (
 	"github.com/simelo/rextporter/src/util"
 )
 
+type TokenCreator struct {
+	UriToGenToken string
+}
+
+func (tc TokenCreator) CreateClient() (cl Client, err error) {
+	return newTokenClient(tc.UriToGenToken)
+}
+
 // TokenClient implements the getRemoteInfo method from `client.Client` interface by using some .toml config parameters
 // like for example: where is the host? it should be a GET, a POST or some other ... It works like an http wrapper to
 // to get a token from the server.

--- a/src/client/worker_queue.go
+++ b/src/client/worker_queue.go
@@ -1,0 +1,129 @@
+package client
+
+import (
+	"log"
+	"sync"
+	"time"
+)
+
+type RequestInfo struct {
+	Client Client
+	Res    chan []byte
+	Err    chan error
+}
+
+type workRequest struct {
+	client Client
+	res    chan []byte
+	err    chan error
+}
+
+type workQueue chan workRequest
+type workerQueue chan workQueue
+
+type Pool struct {
+	workers  workerQueue
+	works    workQueue
+	nWorkers uint
+	wg       sync.WaitGroup
+}
+
+func NewPool(workersNum uint) *Pool {
+	return &Pool{
+		workers:  make(chan workQueue, workersNum),
+		works:    make(chan workRequest, workersNum*2),
+		nWorkers: workersNum,
+		wg:       sync.WaitGroup{},
+	}
+}
+
+func (p *Pool) Wait() {
+	p.wg.Wait()
+}
+
+func (p *Pool) Apply(ri RequestInfo) {
+	work := workRequest{client: ri.Client, res: ri.Res, err: ri.Err}
+	p.works <- work
+}
+
+type workerT struct {
+	works    chan workRequest
+	workers  chan workQueue
+	quitChan chan bool
+	wg       *sync.WaitGroup
+}
+
+func (p *Pool) newWorker() workerT {
+	log.Println("creating worker")
+	return workerT{
+		works:    make(chan workRequest),
+		workers:  p.workers,
+		quitChan: make(chan bool),
+		wg:       &p.wg,
+	}
+}
+
+func (w *workerT) start() {
+	log.Println("starting worker")
+	w.wg.Add(1)
+	go func() {
+		for {
+			// Add ourselves as available into the worker queue.
+			w.workers <- w.works
+			select {
+			// Wait for a work request.
+			case work := <-w.works:
+				log.Println("start processing work")
+				time.Sleep(time.Second * 1)
+				log.Println("work.client", work.client)
+				data, err := work.client.GetData()
+				if err == nil {
+					work.res <- data
+				} else {
+					work.err <- err
+				}
+				log.Println("finish processing work")
+				// wait for a quit msg
+			case <-w.quitChan:
+				// Receive a close worker request.
+				w.wg.Done()
+				return
+			}
+		}
+	}()
+}
+
+func (w *workerT) stop() {
+	go func() {
+		w.quitChan <- true
+		// close(w.quitChan)
+	}()
+}
+
+func (p *Pool) Stop() {
+	// for {
+	// 	worker := <-p.workers
+	// 	worker.stop()
+	// }
+}
+
+func (p *Pool) StartDispatcher() {
+	for i := uint(0); i < p.nWorkers; i++ {
+		worker := p.newWorker()
+		worker.start()
+	}
+	go func() {
+		for {
+			select {
+			// wait for an incoming work
+			case work := <-p.works:
+				log.Println("work recived")
+				// wait for an available worker
+				worker := <-p.workers
+				log.Println("worker available")
+				// dispatch work into worker
+				worker <- work
+			}
+		}
+	}()
+}

--- a/src/exporter/exporter.go
+++ b/src/exporter/exporter.go
@@ -52,13 +52,15 @@ func exposedMetricsMiddleware(fs scrapper.Scrapper, promHandler http.Handler) ht
 		var iMetrics interface{}
 		var err error
 		if iMetrics, err = fs.GetMetric(); err != nil {
-			log.WithError(err).Errorln("error getting custom data")
+			log.WithError(err).Errorln("error scrapping fordwader metrics")
 		} else {
-			customData, okCustomData := iMetrics.([]byte)
-			if okCustomData {
-				allData = append(allData, customData...)
-			} else {
-				log.WithError(err).Errorln("error getting custom data")
+			if iMetrics != nil {
+				customData, okCustomData := iMetrics.([]byte)
+				if okCustomData {
+					allData = append(allData, customData...)
+				} else {
+					log.WithError(err).Errorln("error asserting fordwader metrics data as []byte")
+				}
 			}
 		}
 		w.Header().Set("Content-Type", "text/plain")

--- a/src/exporter/metric.go
+++ b/src/exporter/metric.go
@@ -55,14 +55,14 @@ func createMetrics(cache cache.Cache, srvsConf []config.Service) (metrics endpoi
 
 func createConstMetric(cache cache.Cache, metricConf config.Metric, srvConf config.Service) (metric constMetric, err error) {
 	generalScopeErr := "can not create metric " + metricConf.Name
-	var metricClient client.CacheableClient
-	if metricClient, err = client.CreateAPIRest(metricConf, srvConf); err != nil {
+	var ccf client.CacheableClientFactory
+	if ccf, err = client.CreateAPIRestCreator(metricConf, srvConf); err != nil {
 		errCause := fmt.Sprintln("error creating metric client: ", err.Error())
 		return metric, util.ErrorFromThisScope(errCause, generalScopeErr)
 	}
-	clCache := client.NewCatcher(metricClient, cache)
+	cc := client.CatcherCreator{Cache: cache, ClientFactory: ccf}
 	var numScrapper scrapper.Scrapper
-	if numScrapper, err = scrapper.NewScrapper(clCache, scrapper.JSONParser{}, metricConf); err != nil {
+	if numScrapper, err = scrapper.NewScrapper(cc, scrapper.JSONParser{}, metricConf); err != nil {
 		errCause := fmt.Sprintln("error creating metric client: ", err.Error())
 		return metric, util.ErrorFromThisScope(errCause, generalScopeErr)
 	}

--- a/src/exporter/metric.go
+++ b/src/exporter/metric.go
@@ -55,7 +55,7 @@ func createMetrics(cache cache.Cache, srvsConf []config.Service) (metrics endpoi
 
 func createConstMetric(cache cache.Cache, metricConf config.Metric, srvConf config.Service) (metric constMetric, err error) {
 	generalScopeErr := "can not create metric " + metricConf.Name
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	if ccf, err = client.CreateAPIRestCreator(metricConf, srvConf); err != nil {
 		errCause := fmt.Sprintln("error creating metric client: ", err.Error())
 		return metric, util.ErrorFromThisScope(errCause, generalScopeErr)

--- a/src/exporter/metric.go
+++ b/src/exporter/metric.go
@@ -14,15 +14,15 @@ import (
 func createMetricsForwaders(conf config.RootConfig) (scrapper.Scrapper, error) {
 	generalScopeErr := "can not create metrics Middleware"
 	services := conf.FilterServicesByType(config.ServiceTypeProxy)
-	proxyMetricClients := make([]client.ProxyMetricClient, len(services))
+	proxyMetricClientCreators := make([]client.ProxyMetricClientCreator, len(services))
 	for idxService := range services {
 		var err error
-		if proxyMetricClients[idxService], err = client.NewProxyMetricClient(services[idxService]); err != nil {
+		if proxyMetricClientCreators[idxService], err = client.CreateProxyMetricClientCreator(services[idxService]); err != nil {
 			errCause := fmt.Sprintln("error creating metric client: ", err.Error())
 			return nil, util.ErrorFromThisScope(errCause, generalScopeErr)
 		}
 	}
-	return scrapper.NewMetricsForwaders(proxyMetricClients), nil
+	return scrapper.NewMetricsForwaders(proxyMetricClientCreators), nil
 }
 
 // constMetric has a scrapper to get remote data, can be a previously cached content

--- a/src/scrapper/histogram.go
+++ b/src/scrapper/histogram.go
@@ -17,9 +17,9 @@ type Histogram struct {
 	buckets histogramClientOptions
 }
 
-func newHistogram(client client.Client, parser BodyParser, metric config.Metric) Scrapper {
+func newHistogram(cf client.ClientFactory, parser BodyParser, metric config.Metric) Scrapper {
 	return Histogram{
-		baseScrapper: baseScrapper{client: client, parser: parser, jsonPath: metric.Path},
+		baseScrapper: baseScrapper{clientFactory: cf, parser: parser, jsonPath: metric.Path},
 		buckets:      histogramClientOptions(metric.HistogramOptions.Buckets),
 	}
 }
@@ -28,7 +28,7 @@ func newHistogram(client client.Client, parser BodyParser, metric config.Metric)
 func (h Histogram) GetMetric() (val interface{}, err error) {
 	const generalScopeErr = "error scrapping histogram metric"
 	var iBody interface{}
-	if iBody, err = getData(h.client, h.parser); err != nil {
+	if iBody, err = getData(h.clientFactory, h.parser); err != nil {
 		errCause := "histogram client can not decode the body"
 		return val, util.ErrorFromThisScope(errCause, generalScopeErr)
 	}

--- a/src/scrapper/histogram.go
+++ b/src/scrapper/histogram.go
@@ -17,7 +17,7 @@ type Histogram struct {
 	buckets histogramClientOptions
 }
 
-func newHistogram(cf client.ClientFactory, parser BodyParser, metric config.Metric) Scrapper {
+func newHistogram(cf client.Factory, parser BodyParser, metric config.Metric) Scrapper {
 	return Histogram{
 		baseScrapper: baseScrapper{clientFactory: cf, parser: parser, jsonPath: metric.Path},
 		buckets:      histogramClientOptions(metric.HistogramOptions.Buckets),

--- a/src/scrapper/init.go
+++ b/src/scrapper/init.go
@@ -1,0 +1,12 @@
+package scrapper
+
+import (
+	"github.com/simelo/rextporter/src/client"
+)
+
+var workPool *client.Pool
+
+func init() {
+	workPool = client.NewPool(6)
+	workPool.StartDispatcher()
+}

--- a/src/scrapper/init.go
+++ b/src/scrapper/init.go
@@ -1,12 +1,8 @@
 package scrapper
 
-import (
-	"github.com/simelo/rextporter/src/client"
-)
-
-var workPool *client.Pool
+var WorkPool *Pool
 
 func init() {
-	workPool = client.NewPool(6)
-	workPool.StartDispatcher()
+	WorkPool = NewPool(6)
+	WorkPool.StartDispatcher()
 }

--- a/src/scrapper/init.go
+++ b/src/scrapper/init.go
@@ -1,5 +1,6 @@
 package scrapper
 
+// WorkPool is use to run scrapper task in goroutines
 var WorkPool *Pool
 
 func init() {

--- a/src/scrapper/metrics_forwader.go
+++ b/src/scrapper/metrics_forwader.go
@@ -68,7 +68,7 @@ func appendPrefixForMetrics(prefix string, metricsData string) ([]byte, error) {
 // GetMetric return the original metrics but with a service name as prefix in his names
 func (mfs MetricsForwaders) GetMetric() (val interface{}, err error) {
 	getCustomData := func() (data []byte, err error) {
-		generalScopeErr := "Error getting custom data"
+		generalScopeErr := "Error getting custom data for metrics fordwader"
 		recorder := httptest.NewRecorder()
 		for _, mf := range mfs.servicesMetricsForwader {
 			var cl client.Client

--- a/src/scrapper/numeric.go
+++ b/src/scrapper/numeric.go
@@ -12,15 +12,15 @@ type Numeric struct {
 	baseScrapper
 }
 
-func newNumeric(cl client.Client, p BodyParser, path string) Scrapper {
-	return Numeric{baseScrapper: baseScrapper{client: cl, parser: p, jsonPath: path}}
+func newNumeric(cf client.ClientFactory, p BodyParser, path string) Scrapper {
+	return Numeric{baseScrapper: baseScrapper{clientFactory: cf, parser: p, jsonPath: path}}
 }
 
 // GetMetric returns a single number with the metric value, is a counter or a gauge
 func (n Numeric) GetMetric() (val interface{}, err error) {
 	const generalScopeErr = "error scrapping numeric(gauge|counter) metric"
 	var iBody interface{}
-	if iBody, err = getData(n.client, n.parser); err != nil {
+	if iBody, err = getData(n.clientFactory, n.parser); err != nil {
 		errCause := "numeric client can not decode the body"
 		return val, util.ErrorFromThisScope(errCause, generalScopeErr)
 	}

--- a/src/scrapper/numeric.go
+++ b/src/scrapper/numeric.go
@@ -12,7 +12,7 @@ type Numeric struct {
 	baseScrapper
 }
 
-func newNumeric(cf client.ClientFactory, p BodyParser, path string) Scrapper {
+func newNumeric(cf client.Factory, p BodyParser, path string) Scrapper {
 	return Numeric{baseScrapper: baseScrapper{clientFactory: cf, parser: p, jsonPath: path}}
 }
 

--- a/src/scrapper/numeric_test.go
+++ b/src/scrapper/numeric_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/simelo/rextporter/src/cache"
 	"github.com/simelo/rextporter/src/client"
 	"github.com/simelo/rextporter/src/config"
 	log "github.com/sirupsen/logrus"
@@ -55,11 +56,17 @@ func httpHandler(w http.ResponseWriter, r *http.Request) {
 type numericStatsSuit struct {
 	suite.Suite
 	testServer *httptest.Server
+	cache      cache.Cache
 }
 
 func (suite *numericStatsSuit) SetupSuite() {
+	suite.cache = cache.NewCache()
 	suite.testServer = stubSkycoin()
 	suite.testServer.Start()
+}
+
+func (suite *numericStatsSuit) SetupTest() {
+	suite.cache.Reset()
 }
 
 func (suite *numericStatsSuit) TearDownSuite() {
@@ -117,11 +124,12 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadSeq() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -169,11 +177,12 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadBlockHash() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -221,11 +230,12 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadPreviousBlockHash() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -273,11 +283,12 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadTimestamp() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -325,11 +336,12 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadFee() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -377,11 +389,12 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadVersion() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -429,11 +442,12 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadTxBodyHash() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -481,11 +495,12 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadUxHash() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -533,11 +548,12 @@ func (suite *numericStatsSuit) TestMetricBlockchainUnspens() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -585,11 +601,12 @@ func (suite *numericStatsSuit) TestMetricBlockchainUnconfirmed() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -637,11 +654,12 @@ func (suite *numericStatsSuit) TestMetricBlockchainTimeSinceLastBlock() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -689,11 +707,12 @@ func (suite *numericStatsSuit) TestMetricVersionVersion() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -741,11 +760,12 @@ func (suite *numericStatsSuit) TestMetricVersionCommit() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -793,11 +813,12 @@ func (suite *numericStatsSuit) TestMetricVersionBranch() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -845,11 +866,12 @@ func (suite *numericStatsSuit) TestMetricOpenConnections() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -897,11 +919,12 @@ func (suite *numericStatsSuit) TestMetricUptime() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -949,11 +972,12 @@ func (suite *numericStatsSuit) TestMetricCsrfEnabled() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -1001,11 +1025,12 @@ func (suite *numericStatsSuit) TestMetricCspEnabled() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -1053,11 +1078,12 @@ func (suite *numericStatsSuit) TestMetricWalletApiEnabled() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -1105,11 +1131,12 @@ func (suite *numericStatsSuit) TestMetricGuiEnabled() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -1157,11 +1184,12 @@ func (suite *numericStatsSuit) TestMetricUnversionedApiEnabled() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When
@@ -1209,11 +1237,12 @@ func (suite *numericStatsSuit) TestMetricJsonRpcEnabled() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var cl client.Client
-	cl, err = client.CreateAPIRest(metricConf, serviceConf)
+	var ccf client.CacheableClientFactory
+	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
+	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
 	var sc Scrapper
-	sc, err = NewScrapper(cl, JSONParser{}, metricConf)
+	sc, err = NewScrapper(cc, JSONParser{}, metricConf)
 	require.Nil(err)
 
 	// NOTE(denisacostaq@gmail.com): When

--- a/src/scrapper/numeric_test.go
+++ b/src/scrapper/numeric_test.go
@@ -124,7 +124,7 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadSeq() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -177,7 +177,7 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadBlockHash() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -230,7 +230,7 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadPreviousBlockHash() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -283,7 +283,7 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadTimestamp() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -336,7 +336,7 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadFee() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -389,7 +389,7 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadVersion() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -442,7 +442,7 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadTxBodyHash() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -495,7 +495,7 @@ func (suite *numericStatsSuit) TestMetricBlockChainHeadUxHash() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -548,7 +548,7 @@ func (suite *numericStatsSuit) TestMetricBlockchainUnspens() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -601,7 +601,7 @@ func (suite *numericStatsSuit) TestMetricBlockchainUnconfirmed() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -654,7 +654,7 @@ func (suite *numericStatsSuit) TestMetricBlockchainTimeSinceLastBlock() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -707,7 +707,7 @@ func (suite *numericStatsSuit) TestMetricVersionVersion() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -760,7 +760,7 @@ func (suite *numericStatsSuit) TestMetricVersionCommit() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -813,7 +813,7 @@ func (suite *numericStatsSuit) TestMetricVersionBranch() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -866,7 +866,7 @@ func (suite *numericStatsSuit) TestMetricOpenConnections() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -919,7 +919,7 @@ func (suite *numericStatsSuit) TestMetricUptime() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -972,7 +972,7 @@ func (suite *numericStatsSuit) TestMetricCsrfEnabled() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -1025,7 +1025,7 @@ func (suite *numericStatsSuit) TestMetricCspEnabled() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -1078,7 +1078,7 @@ func (suite *numericStatsSuit) TestMetricWalletApiEnabled() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -1131,7 +1131,7 @@ func (suite *numericStatsSuit) TestMetricGuiEnabled() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -1184,7 +1184,7 @@ func (suite *numericStatsSuit) TestMetricUnversionedApiEnabled() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}
@@ -1237,7 +1237,7 @@ func (suite *numericStatsSuit) TestMetricJsonRpcEnabled() {
 	require.Len(conf.Services[0].Metrics, 1)
 	serviceConf := conf.Services[0]
 	metricConf := conf.Services[0].Metrics[0]
-	var ccf client.CacheableClientFactory
+	var ccf client.CacheableFactory
 	ccf, err = client.CreateAPIRestCreator(metricConf, serviceConf)
 	require.Nil(err)
 	cc := client.CatcherCreator{Cache: suite.cache, ClientFactory: ccf}

--- a/src/scrapper/numeric_vec.go
+++ b/src/scrapper/numeric_vec.go
@@ -16,9 +16,9 @@ type NumericVec struct {
 	itemPath   string
 }
 
-func newNumericVec(cl client.Client, p BodyParser, metric config.Metric) Scrapper {
+func newNumericVec(cf client.ClientFactory, p BodyParser, metric config.Metric) Scrapper {
 	return NumericVec{
-		baseScrapper: baseScrapper{client: cl, parser: p, jsonPath: metric.Path},
+		baseScrapper: baseScrapper{clientFactory: cf, parser: p, jsonPath: metric.Path},
 		labels:       metric.Options.Labels,
 		labelsName:   metric.LabelNames(),
 		itemPath:     metric.Options.ItemPath}
@@ -37,7 +37,7 @@ type NumericVecVals []NumericVecItemVal
 func (nv NumericVec) GetMetric() (val interface{}, err error) {
 	const generalScopeErr = "error scrapping numeric vec(gauge|counter) metric vec"
 	var iBody interface{}
-	if iBody, err = getData(nv.client, nv.parser); err != nil {
+	if iBody, err = getData(nv.clientFactory, nv.parser); err != nil {
 		errCause := "numeric vec client can not decode the body"
 		return val, util.ErrorFromThisScope(errCause, generalScopeErr)
 	}

--- a/src/scrapper/numeric_vec.go
+++ b/src/scrapper/numeric_vec.go
@@ -16,7 +16,7 @@ type NumericVec struct {
 	itemPath   string
 }
 
-func newNumericVec(cf client.ClientFactory, p BodyParser, metric config.Metric) Scrapper {
+func newNumericVec(cf client.Factory, p BodyParser, metric config.Metric) Scrapper {
 	return NumericVec{
 		baseScrapper: baseScrapper{clientFactory: cf, parser: p, jsonPath: metric.Path},
 		labels:       metric.Options.Labels,

--- a/src/scrapper/scrapper.go
+++ b/src/scrapper/scrapper.go
@@ -15,7 +15,7 @@ type Scrapper interface {
 }
 
 type baseScrapper struct {
-	clientFactory client.ClientFactory
+	clientFactory client.Factory
 	parser        BodyParser
 	jsonPath      string
 }
@@ -27,21 +27,21 @@ type BodyParser interface {
 }
 
 // NewScrapper will put all the required info to scrap metrics from the body returned by the client.
-func NewScrapper(cf client.ClientFactory, parser BodyParser, metric config.Metric) (Scrapper, error) {
+func NewScrapper(cf client.Factory, parser BodyParser, metric config.Metric) (Scrapper, error) {
 	if len(metric.LabelNames()) > 0 {
 		return createVecScrapper(cf, parser, metric)
 	}
 	return createAtomicScrapper(cf, parser, metric)
 }
 
-func createVecScrapper(cf client.ClientFactory, parser BodyParser, metric config.Metric) (Scrapper, error) {
+func createVecScrapper(cf client.Factory, parser BodyParser, metric config.Metric) (Scrapper, error) {
 	if metric.Options.Type == config.KeyTypeCounter || metric.Options.Type == config.KeyTypeGauge {
 		return newNumericVec(cf, parser, metric), nil
 	}
 	return NumericVec{}, errors.New("histogram vec and summary vec are not supported yet")
 }
 
-func createAtomicScrapper(cf client.ClientFactory, parser BodyParser, metric config.Metric) (Scrapper, error) {
+func createAtomicScrapper(cf client.Factory, parser BodyParser, metric config.Metric) (Scrapper, error) {
 	if metric.Options.Type == config.KeyTypeSummary {
 		return Histogram{}, errors.New("summary scrapper is not supported yet")
 	}
@@ -51,7 +51,7 @@ func createAtomicScrapper(cf client.ClientFactory, parser BodyParser, metric con
 	return newNumeric(cf, parser, metric.Path), nil
 }
 
-func getData(cf client.ClientFactory, p BodyParser) (data interface{}, err error) {
+func getData(cf client.Factory, p BodyParser) (data interface{}, err error) {
 	const generalScopeErr = "error getting data"
 	var cl client.Client
 	if cl, err = cf.CreateClient(); err != nil {

--- a/src/scrapper/scrapper.go
+++ b/src/scrapper/scrapper.go
@@ -58,20 +58,14 @@ func getData(cf client.ClientFactory, p BodyParser) (data interface{}, err error
 		errCause := "can ot create client"
 		return data, util.ErrorFromThisScope(errCause, generalScopeErr)
 	}
-	respC := make(chan []byte)
-	defer close(respC)
-	errC := make(chan error)
-	defer close(errC)
-	workPool.Apply(client.RequestInfo{Client: cl, Res: respC, Err: errC})
-	select {
-	case body := <-respC:
-		if data, err = p.decodeBody(body); err != nil {
-			errCause := "scrapper can not decode the body"
-			return data, util.ErrorFromThisScope(errCause, generalScopeErr)
-		}
-		return data, err
-	case err = <-errC:
+	var body []byte
+	if body, err = cl.GetData(); err != nil {
 		errCause := "client can not get data"
 		return data, util.ErrorFromThisScope(errCause, generalScopeErr)
 	}
+	if data, err = p.decodeBody(body); err != nil {
+		errCause := "scrapper can not decode the body"
+		return data, util.ErrorFromThisScope(errCause, generalScopeErr)
+	}
+	return data, err
 }

--- a/src/scrapper/scrapper.go
+++ b/src/scrapper/scrapper.go
@@ -15,9 +15,9 @@ type Scrapper interface {
 }
 
 type baseScrapper struct {
-	client   client.Client
-	parser   BodyParser
-	jsonPath string
+	clientFactory client.ClientFactory
+	parser        BodyParser
+	jsonPath      string
 }
 
 // BodyParser decode body from different formats, an get some data node
@@ -27,32 +27,37 @@ type BodyParser interface {
 }
 
 // NewScrapper will put all the required info to scrap metrics from the body returned by the client.
-func NewScrapper(client client.Client, parser BodyParser, metric config.Metric) (Scrapper, error) {
+func NewScrapper(cf client.ClientFactory, parser BodyParser, metric config.Metric) (Scrapper, error) {
 	if len(metric.LabelNames()) > 0 {
-		return createVecScrapper(client, parser, metric)
+		return createVecScrapper(cf, parser, metric)
 	}
-	return createAtomicScrapper(client, parser, metric)
+	return createAtomicScrapper(cf, parser, metric)
 }
 
-func createVecScrapper(client client.Client, parser BodyParser, metric config.Metric) (Scrapper, error) {
+func createVecScrapper(cf client.ClientFactory, parser BodyParser, metric config.Metric) (Scrapper, error) {
 	if metric.Options.Type == config.KeyTypeCounter || metric.Options.Type == config.KeyTypeGauge {
-		return newNumericVec(client, parser, metric), nil
+		return newNumericVec(cf, parser, metric), nil
 	}
 	return NumericVec{}, errors.New("histogram vec and summary vec are not supported yet")
 }
 
-func createAtomicScrapper(client client.Client, parser BodyParser, metric config.Metric) (Scrapper, error) {
+func createAtomicScrapper(cf client.ClientFactory, parser BodyParser, metric config.Metric) (Scrapper, error) {
 	if metric.Options.Type == config.KeyTypeSummary {
 		return Histogram{}, errors.New("summary scrapper is not supported yet")
 	}
 	if metric.Options.Type == config.KeyTypeHistogram {
-		return newHistogram(client, parser, metric), nil
+		return newHistogram(cf, parser, metric), nil
 	}
-	return newNumeric(client, parser, metric.Path), nil
+	return newNumeric(cf, parser, metric.Path), nil
 }
 
-func getData(cl client.Client, p BodyParser) (data interface{}, err error) {
+func getData(cf client.ClientFactory, p BodyParser) (data interface{}, err error) {
 	const generalScopeErr = "error getting data"
+	var cl client.Client
+	if cl, err = cf.CreateClient(); err != nil {
+		errCause := "can ot create client"
+		return data, util.ErrorFromThisScope(errCause, generalScopeErr)
+	}
 	var body []byte
 	if body, err = cl.GetData(); err != nil {
 		errCause := "client can not get data"

--- a/src/scrapper/worker_queue.go
+++ b/src/scrapper/worker_queue.go
@@ -1,9 +1,7 @@
 package scrapper
 
 import (
-	"log"
 	"sync"
-	"time"
 )
 
 type ScrapResult struct {
@@ -71,7 +69,6 @@ type workerT struct {
 }
 
 func (p *Pool) newWorker() workerT {
-	log.Println("creating worker")
 	return workerT{
 		works:    make(chan scrapWork),
 		workers:  p.workers,
@@ -81,7 +78,6 @@ func (p *Pool) newWorker() workerT {
 }
 
 func (w *workerT) start() {
-	log.Println("starting worker")
 	w.wg.Add(1)
 	go func() {
 		for {
@@ -90,16 +86,12 @@ func (w *workerT) start() {
 			select {
 			// Wait for a work request.
 			case work := <-w.works:
-				log.Println("start processing work")
-				time.Sleep(time.Second * 1)
-				log.Println("work.client", work.scrapper)
 				val, err := work.scrapper.GetMetric()
 				if err == nil {
 					work.res <- ScrapResult{Val: val, ConstMetricIdxOut: work.constMetricIdxIn}
 				} else {
 					work.err <- ScrapErrResult{Err: err, ConstMetricIdxOut: work.constMetricIdxIn}
 				}
-				log.Println("finish processing work")
 				// wait for a quit msg
 			case <-w.quitChan:
 				// Receive a close worker request.
@@ -134,10 +126,8 @@ func (p *Pool) StartDispatcher() {
 			select {
 			// wait for an incoming work
 			case work := <-p.works:
-				log.Println("work recived")
 				// wait for an available worker
 				worker := <-p.workers
-				log.Println("worker available")
 				// dispatch work into worker
 				worker <- work
 			}

--- a/src/scrapper/worker_queue.go
+++ b/src/scrapper/worker_queue.go
@@ -1,4 +1,4 @@
-package client
+package scrapper
 
 import (
 	"log"


### PR DESCRIPTION
closes #53

Changes:

- create a factory that create clients
- create a workers pool to run scraps
- run scraps inside `workersPool`

Does this change need to mentioned in CHANGELOG.md? no
