### PR TITLE
[ci] fixes #64 - Github issue and PR templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,27 @@
+
+Issue tracker is **ONLY** used for reporting bugs, features and enhancements. NO SUPPORT TICKETS ACCEPTED! Use [stackoverflow](https://stackoverflow.com) for supporting issues.
+
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Steps to Reproduce the Problem
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+
+  1.
+  1.
+  1.
+
+## Specifications
+
+  - Version:
+  - Platform:
+  - Subsystem:
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- Not obligatory, but suggest an idea for implementing addition or change -->
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,10 @@
+
 Fixes #
 
 Changes:
-
 -
 
 Does this change need to mentioned in CHANGELOG.md?
+
+Yes | No
+


### PR DESCRIPTION
Fixes #64 

Changes:

- Update github PR template
- Add github issue template

Does this change need to mentioned in CHANGELOG.md?

No
