### PR TITLE
[ci] fixes #68 - Do not run integration tests on Mac OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ script:
   - make test-386
   - make test-amd64
   - curl http://localhost:6420/api/v1/network/connections
-  - make integration-test-386
-  - make integration-test-amd64
+  - if [ "$TRAVIS_OS_NAME" != "osx" ]; then make integration-test-386 ; fi
+  - if [ "$TRAVIS_OS_NAME" != "osx" ]; then make integration-test-amd64 ; fi
 
 after_script:
   - docker images


### PR DESCRIPTION
... since services not supported on Travis osx build jobs
https://docs.travis-ci.com/user/docker/

Fixes #68 

Changes:
- Do not run integration tests on Travis if `os=osx`

Does this change need to mentioned in CHANGELOG.md?

No

