### PR TITLE
[ci] fixes #68 - During Travis build Only probe Docker container on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ script:
   - make lint
   - make test-386
   - make test-amd64
-  - curl http://localhost:6420/api/v1/network/connections
+  # Probe Docker container to know it's up and running
+  - if [ "$TRAVIS_OS_NAME" != "osx" ]; then curl http://localhost:6420/api/v1/network/connections ; fi
   - if [ "$TRAVIS_OS_NAME" != "osx" ]; then make integration-test-386 ; fi
   - if [ "$TRAVIS_OS_NAME" != "osx" ]; then make integration-test-amd64 ; fi
 


### PR DESCRIPTION
Fixes #68 . Follow up to #70 

Changes:
- During Travis build Only probe Docker container on linux

Does this change need to mentioned in CHANGELOG.md?

No

